### PR TITLE
Bug: Component will keep begging for next page

### DIFF
--- a/package/index.tsx
+++ b/package/index.tsx
@@ -27,7 +27,7 @@ export const InfiniteScroller = React.forwardRef<
     React.useEffect(() => {
       const observer = new IntersectionObserver(
         (entries) => {
-          if (entries[0]?.isIntersecting) fetchNextPage();
+          if (entries[0]?.isIntersecting && hasNextPage) fetchNextPage();
         },
         { threshold: 1 }
       );


### PR DESCRIPTION
Hi there,

Just a quick fix actually. I noticed that even though I passed `hasNextPage=false`, it'll keep asking my next() function to give the next page. I'm able to intercept it in the next() function to check whether there is next page or not, but I think it's somewhat an unexpected behavior for the library to keep asking? Hence this PR.

Happy to hear from you :)